### PR TITLE
fix(Assigments): fix deleting an assigment

### DIFF
--- a/src/tasks/Assignments.js
+++ b/src/tasks/Assignments.js
@@ -36,7 +36,7 @@ function actions({getStuff, models}) {
       assignment: key,
     })
     .then(({assignment}) =>
-      models.Assignments.child(key).remove().then(assignment)
+      models.Assignments.child(key).remove().then(() => assignment)
     )
     .then(
       ifElse(
@@ -46,7 +46,7 @@ function actions({getStuff, models}) {
             role:'Shifts',
             cmd:'updateCounts',
             key:assignment.shiftKey,
-          }).then(assignment),
+          }).then(() => assignment),
         identity
       )
     )


### PR DESCRIPTION
The bug that occurs when assignments are not deleted, the shift counts never
decrease but increase past the number allowed and lock shifts that can actually have
0 people assigned to complete
