### PR TITLE
79 do not check the organizer email matches the invite email when accepting invites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,6 @@ node_modules
 # Optional REPL history
 .node_repl_history
 
+.idea
+
 dist

--- a/src/tasks/Organizers.js
+++ b/src/tasks/Organizers.js
@@ -50,8 +50,7 @@ function actions({auths: {userCanUpdateProject}, models: {Organizers}, getStuff}
     profile &&
     organizer &&
     not(organizer.isAccepted) &&
-    not(organizer.profileKey) &&
-    equals(organizer.inviteEmail, profile.email)
+    not(organizer.profileKey)
 
   const rejectCannotAccept = unless(canAccept, ({profile, organizer}) =>
     Promise.reject(


### PR DESCRIPTION
I did : 
- remove webstorm config files from git file tracking
- add line in .gitignore to automatically avoid the issue in subsequent push
- add the fix on the backend which removes the email check as requested per the bug description
