### PR TITLE
chore(META): generate an automated changelog

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["babel-preset-es2015", "babel-preset-stage-0"]
+  "presets": ["es2015", "stage-2"]
 }

--- a/.cz-config.js
+++ b/.cz-config.js
@@ -20,6 +20,9 @@ module.exports = {
   ],
 
   scopeOverrides: {
+    chore: [
+      {name: 'META - (overall changes that affect the repo)'},
+    ]
   },
 
   allowCustomScopes: true,

--- a/.cz-config.js
+++ b/.cz-config.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  types: [
+    {value: 'feat',     name: 'feat:     Add a new feature'},
+    {value: 'fix',      name: 'fix:      Submit a bug fix'},
+    {value: 'refactor', name: 'refactor: A code change that neither fixes a bug nor adds a feature'},
+    {value: 'test',     name: 'test:     Add tests only'},
+    {value: 'docs',     name: 'docs:     Documentation only changes'},
+    {value: 'release',  name: 'release:  Publish a new version of a package.'},
+    {value: 'chore',    name: 'chore:    Changes to the build process or auxiliary tools\n            and libraries such as documentation generation. META only.'},
+    {value: 'style',    name: 'style:    Changes that do not affect the meaning of the code\n            (white-space, formatting, missing semi-colons, etc)'},
+    {value: 'perf',     name: 'perf:     A code change that improves performance'},
+  ],
+
+  scopes: [
+    {name: 'tasks'},
+    {name: 'util'},
+    {name: 'script'},
+  ],
+
+  scopeOverrides: {
+  },
+
+  allowCustomScopes: true,
+  allowBreakingChanges: ['feat', 'fix'],
+};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+<a name="1.0.0"></a>
+# 1.0.0 (2016-08-03)
+
+
+### Bug Fixes
+
+* **Shifts:** fix typo in shifts update ([2d21656](https://github.com/sdebaun/sparks-backend/commit/2d21656))
+* fix filtering by project name ([2a6443b](https://github.com/sdebaun/sparks-backend/commit/2a6443b))
+* **Arrivals,Seneca:** Fix the expected arguments of the arrivals create action ([2f8326a](https://github.com/sdebaun/sparks-backend/commit/2f8326a))
+* **Assigments:** fix deleting an assigment ([9cf993d](https://github.com/sdebaun/sparks-backend/commit/9cf993d))
+* **Assignemnts:** do not attempt to update shift count if assignment has no shift key ([3af8929](https://github.com/sdebaun/sparks-backend/commit/3af8929))
+* **deploy:** add babel-cli to dependencies ([4991cbc](https://github.com/sdebaun/sparks-backend/commit/4991cbc))
+* **Deploy:** Fix the same of the heroku repo ([e1fae35](https://github.com/sdebaun/sparks-backend/commit/e1fae35))
+* **Dispatch:** don't crash when task cannot be processed ([ed30148](https://github.com/sdebaun/sparks-backend/commit/ed30148))
+* **Engagements:** look up profiles by engagement.profileKey ([5d9862e](https://github.com/sdebaun/sparks-backend/commit/5d9862e))
+* **injection:** incorrect initialization of getStuff ([fc55a83](https://github.com/sdebaun/sparks-backend/commit/fc55a83))
+* **Pay:** A callback was being given to a thenable causing errors to be thrown when emails were sent ([1185062](https://github.com/sdebaun/sparks-backend/commit/1185062))
+* **Payments:** Remove tap from promise chain ([c283935](https://github.com/sdebaun/sparks-backend/commit/c283935))
+* Fix the image uploading by returning the set promise, otherwise it does not run ([6f8289e](https://github.com/sdebaun/sparks-backend/commit/6f8289e))
+* fix typo ([9240819](https://github.com/sdebaun/sparks-backend/commit/9240819))
+* **Profiles:** fix import line in profiles ([930b7cc](https://github.com/sdebaun/sparks-backend/commit/930b7cc))
+* **ProjectImages:** allows admins to change the project image ([f9b3ff1](https://github.com/sdebaun/sparks-backend/commit/f9b3ff1))
+* **ProjectImages:** fix broken image setting ([8adfb2d](https://github.com/sdebaun/sparks-backend/commit/8adfb2d))
+* **Shifts:** Do not apply permissions to shifts updateCount action ([8ea4c30](https://github.com/sdebaun/sparks-backend/commit/8ea4c30))
+* **ShiftUpdateCount:** Do not throw an error when seneca task fails, instead return information about the error ([1400d1b](https://github.com/sdebaun/sparks-backend/commit/1400d1b))
+
+
+### Features
+
+* [WIP] - send email when engagament is created ([489de5d](https://github.com/sdebaun/sparks-backend/commit/489de5d))
+* [WIP] only send emails when confirmations are on ([8094b10](https://github.com/sdebaun/sparks-backend/commit/8094b10))
+* acceptance email ([1fec498](https://github.com/sdebaun/sparks-backend/commit/1fec498))
+* add ability to add image ([7534463](https://github.com/sdebaun/sparks-backend/commit/7534463))
+* automatic engagement creation email with template ([4dd266b](https://github.com/sdebaun/sparks-backend/commit/4dd266b))
+* bacis create and update shifts ([970d1c9](https://github.com/sdebaun/sparks-backend/commit/970d1c9))
+* **Arrivals:** Implement arrival creation ([d7217dc](https://github.com/sdebaun/sparks-backend/commit/d7217dc))
+* **ConfirmWithoutPay:** implement confirm without pay action ([3f3bd5f](https://github.com/sdebaun/sparks-backend/commit/3f3bd5f))
+* **Deploy:** Auto deploy backend to production on master branch pushes ([c0085cf](https://github.com/sdebaun/sparks-backend/commit/c0085cf))
+* **Engagements:** send confirmation email ([8c3693b](https://github.com/sdebaun/sparks-backend/commit/8c3693b))
+* **Export:** Do not load all engagements ([337afb3](https://github.com/sdebaun/sparks-backend/commit/337afb3))
+* **Organizers:** send email to invite organizers ([5a18016](https://github.com/sdebaun/sparks-backend/commit/5a18016))
+* **Organizers:** Update all security rules to reflect that organizers ([817d44c](https://github.com/sdebaun/sparks-backend/commit/817d44c))
+* **Seneca:** implement all actions as seneca services ([9357ab2](https://github.com/sdebaun/sparks-backend/commit/9357ab2))
+
+
+

--- a/counts.sh
+++ b/counts.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+echo CONFIRMED
+cat $1 | grep $2 | grep CONFIRMED | wc -l
+echo ACCEPTED
+cat $1 | grep $2 | grep ACCEPTED | wc -l
+echo APPLIED
+cat $1 | grep $2 | grep APPLIED | wc -l

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "node_modules/.bin/babel-node src/index.js",
     "postinstall": "npm run build",
     "build": "node_modules/.bin/babel -d dist src",
-    "test": "node_modules/.bin/babel-tape-runner src/**/*.test.js"
+    "testonce": "node_modules/.bin/babel-tape-runner src/**/*.test.js | ./node_modules/.bin/tap-spec",
+    "test": "watch 'npm run testonce' src/"
   },
   "repository": {
     "type": "git",
@@ -34,12 +35,15 @@
     "gulp-babel": "^6.1.2",
     "gulp-nodemon": "^2.0.6",
     "gulp-plumber": "^1.1.0",
-    "tape": "^4.5.1"
+    "tap-spec": "^4.1.1",
+    "tape": "^4.5.1",
+    "watch": "^0.19.1"
   },
   "dependencies": {
     "babel-cli": "^6.10.1",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
+    "babel-preset-stage-2": "^6.11.0",
     "bluebird": "^3.4.0",
     "braintree": "^1.37.1",
     "braintree-node": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "start": "node_modules/.bin/babel-node src/index.js",
     "postinstall": "npm run build",
     "build": "node_modules/.bin/babel -d dist src",
-    "testonce": "node_modules/.bin/babel-tape-runner src/**/*.test.js | ./node_modules/.bin/tap-spec",
-    "test": "watch 'npm run testonce' src/"
+    "test": "node_modules/.bin/babel-tape-runner src/**/*.test.js | ./node_modules/.bin/tap-spec",
+    "watch": "watch 'npm run testonce' src/"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     },
     "cz-customizable": {
       "config": ".cz-config.js"
+    },
+    "ghooks": {
+      "commit-msg": "node ./node_modules/validate-commit-msg/index.js"
     }
   },
   "devDependencies": {
@@ -45,12 +48,14 @@
     "eslint-loader": "^1.3.0",
     "eslint-plugin-cycle": "^1.0.2",
     "eslint-plugin-no-class": "^0.1.0",
+    "ghooks": "^1.3.2",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-nodemon": "^2.0.6",
     "gulp-plumber": "^1.1.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.5.1",
+    "validate-commit-msg": "^2.6.1",
     "watch": "^0.19.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postinstall": "npm run build",
     "build": "node_modules/.bin/babel -d dist src",
     "test": "node_modules/.bin/babel-tape-runner src/**/*.test.js | ./node_modules/.bin/tap-spec",
-    "watch": "watch 'npm run testonce' src/"
+    "watch": "watch 'npm run test' src/"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "braintree": "^1.37.1",
     "braintree-node": "^1.0.9",
     "express": "^4.13.4",
+    "fast-csv": "^2.0.0",
     "firebase": "^2.4.1",
     "firebase-queue": "^1.2.1",
     "inflection": "^1.10.0",
@@ -56,6 +57,7 @@
     "ramda": "^0.21.0",
     "rx": "^4.0.8",
     "sendgrid": "^2.0.0",
-    "seneca": "^2.1.0"
+    "seneca": "^2.1.0",
+    "twilio": "^2.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "postinstall": "npm run build",
     "build": "node_modules/.bin/babel -d dist src",
     "test": "node_modules/.bin/babel-tape-runner src/**/*.test.js | ./node_modules/.bin/tap-spec",
-    "watch": "watch 'npm run test' src/"
+    "watch": "watch 'npm run test' src/",
+    "commit": "git-cz",
+    "changelog": "conventional-changelog --infile CHANGELOG.md --same-file --release-count 0 --preset angular"
   },
   "repository": {
     "type": "git",
@@ -22,10 +24,22 @@
     "url": "https://github.com/sdebaun/sparks-backend/issues"
   },
   "homepage": "https://github.com/sdebaun/sparks-backend#readme",
+  "config": {
+    "commitizen": {
+      "path": "node_modules/cz-customizable"
+    },
+    "cz-customizable": {
+      "config": ".cz-config.js"
+    }
+  },
   "devDependencies": {
     "babel-eslint": "^5.0.0",
     "babel-tape-runner": "^2.0.1",
     "blue-tape": "^0.2.0",
+    "commitizen": "^2.8.4",
+    "conventional-changelog": "^1.1.0",
+    "conventional-changelog-cli": "^1.2.0",
+    "cz-customizable": "^4.0.0",
     "eslint": "^1.10.3",
     "eslint-config-cycle": "^3.2.0",
     "eslint-loader": "^1.3.0",

--- a/src/authorization.test.js
+++ b/src/authorization.test.js
@@ -46,7 +46,7 @@ test('userCanCreateProject', t => {
     .then(d => t.equal(d.profile, profile)))
 })
 
-test.only('userCanUpdateProject', t => {
+test('userCanUpdateProject', t => {
   const authWithProfile = p => {
     profile = p
     return auths.userCanUpdateProject({uid, projectKey})

--- a/src/export-all.js
+++ b/src/export-all.js
@@ -1,0 +1,9 @@
+import {generateEmailRecords} from './exporting'
+
+generateEmailRecords(process.env.FIREBASE_HOST)
+.then(rows => {
+  rows.map(row => console.log(row))
+  process.exit()
+})
+.catch(err => console.log(err))
+

--- a/src/exporting.js
+++ b/src/exporting.js
@@ -1,0 +1,94 @@
+import {identity, join, toPairs, filter, has, cond, always, pipe, map} from 'ramda'
+import {format} from 'util'
+import Firebase from 'firebase'
+
+export const quoter = str => format('"%s"', str)
+
+export const toCsv = map(pipe(map(quoter),join(',')))
+
+export const toRecord = ([key,vals]) => {return {key, ...vals}}
+
+export const toRows = pipe(toPairs, map(toRecord))
+
+export function lookupsFrom(host) {
+  const fb = new Firebase(host)
+  const all = m =>
+    fb.child(m).once('value').then(snap => snap.val())
+  const one = (m,k) =>
+    fb.child(m).child(k).once('value').then(snap => snap.val())
+
+  return {
+    Engagements: async function() { return all('Engagements') },
+    Profile: async function(key) { return one('Profiles', key) },
+    Project: async function(key) { return one('Projects', key) },
+    Opp: async function(key) { return one('Opps', key) },
+  }
+}
+
+export function dummyLookups() {
+  return {
+    Engagements: async function() {
+      return {
+        ENG1: {oppKey: 'OPP1', profileKey: 'PRO1'},
+        ENG2: {oppKey: 'OPP1', profileKey: 'PRO2'},
+        ENG3: {oppKey: 'OPP2', profileKey: 'PRO3'},
+      }
+    },
+    Profile: async function(key) { return {fullName: 'Profile ' + key, email: 'email', phone: 'phone'} },
+    Project: async function(key) { return {name: 'Proj ' + key} },
+    Opp: async function(key) { return {name: 'Opp ' + key, projectKey: 'PROJ1'} },
+  }
+}
+
+const statusCode = cond([
+  [has('declined'), always('REJECTED')],
+  [has('isConfirmed'), always('CONFIRMED')],
+  [has('isAccepted'), always('ACCEPTED')],
+  [has('isApplied'), always('APPLIED')],
+])
+// function statusCode({isApplied, isAccepted, isConfirmed, declined}) {
+//   if (declined) { return 'REJECTED' }
+//   if (isConfirmed) { return 'CONFIRMED' }
+//   if (isAccepted) { return 'ACCEPTED' }
+//   if (isApplied) { return 'APPLIED' }
+//   return 'NONE'
+// }
+
+export const lensFields = ({key, profile, project, opp, ...eng}) => [
+  eng.profileKey,
+  profile.fullName,
+  profile.email,
+  profile.phone,
+  key,
+  statusCode(eng),
+  eng.amountPaid || '0.00',
+  opp.projectKey,
+  project.name,
+  eng.oppKey,
+  opp.name,
+]
+
+const filterOrphans = pipe(filter(has('profileKey')), filter(has('oppKey')))
+
+export async function generateEmailRecords(host) {
+  const {Engagements, Profile, Project, Opp} = lookupsFrom(host)
+  // const {Engagements, Profile, Project, Opp} = dummyLookups(host)
+
+  async function relativesFor(eng) {
+    const opp = await Opp(eng.oppKey)
+    if (!opp) { // console.log('no opp!', eng.key, eng.profileKey, eng.oppKey)
+      return false
+    }
+    const [profile, project] = await Promise.all([
+      Profile(eng.profileKey),
+      Project(opp.projectKey),
+    ])
+
+    return {...eng, profile, project, opp}
+  }
+
+  const rows = pipe(toRows, filterOrphans)(await Engagements())
+  const fullRows = await Promise.all(map(relativesFor, rows))
+
+  return pipe(filter(identity), map(lensFields), toCsv)(fullRows)
+}

--- a/src/exporting.js
+++ b/src/exporting.js
@@ -1,4 +1,4 @@
-import {identity, join, toPairs, filter, has, cond, always, pipe, map, equals, prop} from 'ramda'
+import {identity, join, toPairs, filter, has, cond, always, pipe, map, prop} from 'ramda'
 import {format} from 'util'
 import Firebase from 'firebase'
 
@@ -14,15 +14,12 @@ export const toRecord = ([key,vals]) => {return {key, ...vals}}
 // turns a collection object of {key: record} into an array of objects
 export const toRows = pipe(toPairs, map(toRecord))
 
-// i cant believe this doesnt exist in Ramda already???
-export const propTrue = p => pipe(prop(p), equals(true))
-
 // returns the status code for an engagement based on presence of fields
 const statusCode = cond([
-  [propTrue('declined'), always('REJECTED')],
-  [propTrue('isConfirmed'), always('CONFIRMED')],
-  [propTrue('isAccepted'), always('ACCEPTED')],
-  [propTrue('isApplied'), always('APPLIED')],
+  [prop('declined'), always('REJECTED')],
+  [prop('isConfirmed'), always('CONFIRMED')],
+  [prop('isAccepted'), always('ACCEPTED')],
+  [prop('isApplied'), always('APPLIED')],
 ])
 
 export function lookupsFrom(host) {

--- a/src/exporting.test.js
+++ b/src/exporting.test.js
@@ -1,0 +1,20 @@
+import test from 'tape'
+import {rowsToCsv, quoter} from './exporting.js'
+
+const FIXTURES = [['foo', 'bar'], ['baz','boz']]
+
+test('rowsToCsv will convert', t => {
+  const result = rowsToCsv(FIXTURES)
+  t.equal(result.length, FIXTURES.length, 'Has the same number of rows')
+  t.equal(result[0], 'foo,bar', 'First row is CSV')
+  t.equal(result[1], 'baz,boz', 'Second row is CSV')
+  t.end()
+})
+
+test.only('quoter quotes', t => {
+  t.equal(quoter('foo'), '"foo"', 'it quotes things')
+  t.equal(quoter(undefined), '"undefined"', 'it handles undefined')
+  t.equal(quoter(null), '"null"', 'it handles null')
+  t.equal(quoter(1234), '"1234"', 'it handles numbers')
+  t.end()
+})

--- a/src/sms.js
+++ b/src/sms.js
@@ -20,11 +20,3 @@ csv
 .fromPath(filename)
 .on('data', call)
 .on('end', () => console.log('done'))
-
-// twilio.messages.create({
-//   body: 'This is a test from Twilio',
-//   to: '8053129100',
-//   from: process.env.TWILIO_PHONE_NUMBER,
-// }).then(response => {
-//   console.log('sms response:', response)
-// })

--- a/src/sms.js
+++ b/src/sms.js
@@ -7,12 +7,17 @@ async function call(row) {
   const [profileKey, name, email, phone, engKey, status, opp] = row
   console.log('calling', name, phone)
   const response = await twilio.messages.create({
-    body: 'Youve been accepted as a Northern Nights volunteer! Please go to http://sparks.network to confirm or email help@sparks.network to cancel.',
+    body: 'HURRY! Confirm your Northern Nights volunteer spot or lose any shifts you selected. Confirm at http://sparks.network or email help@sparks.network to cancel and stop our texts.',
     to: phone,
     from: process.env.TWILIO_PHONE_NUMBER,
   })
   console.log('response', response)
 }
+
+// async function fakeCall(row) {
+//   const [profileKey, name, email, phone, engKey, status, opp] = row
+//   console.log('calling', name, phone)
+// }
 
 const filename = process.argv[2]
 console.log('opening', filename)

--- a/src/sms.js
+++ b/src/sms.js
@@ -1,0 +1,30 @@
+import Twilio from 'twilio'
+import csv from 'fast-csv'
+
+const twilio = Twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN)
+
+async function call(row) {
+  const [profileKey, name, email, phone, engKey, status, opp] = row
+  console.log('calling', name, phone)
+  const response = await twilio.messages.create({
+    body: 'Youve been accepted as a Northern Nights volunteer! Please go to http://sparks.network to confirm or email help@sparks.network to cancel.',
+    to: phone,
+    from: process.env.TWILIO_PHONE_NUMBER,
+  })
+  console.log('response', response)
+}
+
+const filename = process.argv[2]
+console.log('opening', filename)
+csv
+.fromPath(filename)
+.on('data', call)
+.on('end', () => console.log('done'))
+
+// twilio.messages.create({
+//   body: 'This is a test from Twilio',
+//   to: '8053129100',
+//   from: process.env.TWILIO_PHONE_NUMBER,
+// }).then(response => {
+//   console.log('sms response:', response)
+// })


### PR DESCRIPTION
Example - https://github.com/SparksNetwork/sparks-backend/blob/0f51b2ea3f51bb918130d99b228cbc072175a071/CHANGELOG.md

This introduces a number of pieces. 
`ghooks` and `validate-commit-msg` work together to ensure that **all** commit messages adhere to a particular format of `type(scope): message`. 

`commitizen` and `cz-customizable` work together to get developers to use the the commit message to adhere to the specified format. Please use `npm run commit` instead of `git commit` when writing a commit to use this awesome tool.

`conventional-changelog` and `conventional-changelog-cli` builds on top of the commit messages an allows generating a changelog from the commit messages. 
